### PR TITLE
Feat/screentime

### DIFF
--- a/src/main/java/dev/wetox/WetoxRESTful/exception/MemberNotFoundException.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/exception/MemberNotFoundException.java
@@ -1,0 +1,9 @@
+package dev.wetox.WetoxRESTful.exception;
+
+import static dev.wetox.WetoxRESTful.exception.WetoxErorr.MEMBER_NOT_FOUND;
+
+public class MemberNotFoundException extends WetoxException {
+    public MemberNotFoundException() {
+        super(MEMBER_NOT_FOUND);
+    }
+}

--- a/src/main/java/dev/wetox/WetoxRESTful/exception/ScreenTimeNotFoundException.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/exception/ScreenTimeNotFoundException.java
@@ -1,0 +1,9 @@
+package dev.wetox.WetoxRESTful.exception;
+
+import static dev.wetox.WetoxRESTful.exception.WetoxErorr.SCREEN_TIME_NOT_FOUND;
+
+public class ScreenTimeNotFoundException extends WetoxException {
+    public ScreenTimeNotFoundException() {
+        super(SCREEN_TIME_NOT_FOUND);
+    }
+}

--- a/src/main/java/dev/wetox/WetoxRESTful/exception/WetoxErorr.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/exception/WetoxErorr.java
@@ -5,11 +5,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 @Getter
 @RequiredArgsConstructor
 public enum WetoxErorr {
-    DUPLICATED_USER_REGISTER("중복된 사용자 등록입니다.", BAD_REQUEST)
+    DUPLICATED_USER_REGISTER("중복된 사용자 등록입니다.", BAD_REQUEST),
+    MEMBER_NOT_FOUND("존재하지 않는 사용자입니다.", NOT_FOUND),
     ;
 
     private final String message;

--- a/src/main/java/dev/wetox/WetoxRESTful/exception/WetoxErorr.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/exception/WetoxErorr.java
@@ -12,6 +12,7 @@ import static org.springframework.http.HttpStatus.NOT_FOUND;
 public enum WetoxErorr {
     DUPLICATED_USER_REGISTER("중복된 사용자 등록입니다.", BAD_REQUEST),
     MEMBER_NOT_FOUND("존재하지 않는 사용자입니다.", NOT_FOUND),
+    SCREEN_TIME_NOT_FOUND("스크린 타임이 존재하지 않습니다.", NOT_FOUND),
     ;
 
     private final String message;

--- a/src/main/java/dev/wetox/WetoxRESTful/jwt/JwtService.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/jwt/JwtService.java
@@ -35,7 +35,7 @@ public class JwtService {
                 .setClaims(extraClaims)
                 .setSubject(userDetails.getUsername())
                 .setIssuedAt(new Date(System.currentTimeMillis()))
-                .setExpiration(new Date(System.currentTimeMillis() + 1000))
+                .setExpiration(new Date(System.currentTimeMillis() + 1000 * 60 * 24))
                 .signWith(getSigningKey(), SignatureAlgorithm.HS256)
                 .compact();
     }

--- a/src/main/java/dev/wetox/WetoxRESTful/screentime/AppScreenTime.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/screentime/AppScreenTime.java
@@ -1,14 +1,15 @@
 package dev.wetox.WetoxRESTful.screentime;
 
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 import static jakarta.persistence.FetchType.LAZY;
 
 @Entity
-@Getter
-@Setter
+@Getter @Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class AppScreenTime {
     @Id
     @GeneratedValue

--- a/src/main/java/dev/wetox/WetoxRESTful/screentime/AppScreenTime.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/screentime/AppScreenTime.java
@@ -18,4 +18,10 @@ public class AppScreenTime {
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "screen_time_id")
     private ScreenTime screenTime;
+
+    private String name;
+
+    private String category;
+
+    private Double duration;
 }

--- a/src/main/java/dev/wetox/WetoxRESTful/screentime/AppScreenTime.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/screentime/AppScreenTime.java
@@ -4,12 +4,11 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import static jakarta.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
 
 @Entity
-@Getter @Setter
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
+@Getter
+@NoArgsConstructor(access = PROTECTED)
 public class AppScreenTime {
     @Id
     @GeneratedValue
@@ -25,4 +24,13 @@ public class AppScreenTime {
     private String category;
 
     private Double duration;
+
+    public static AppScreenTime build(ScreenTime screenTime, AppScreenTimeRequest appScreenTimeRequest) {
+        AppScreenTime appScreenTime = new AppScreenTime();
+        appScreenTime.screenTime = screenTime;
+        appScreenTime.name = appScreenTimeRequest.getName();
+        appScreenTime.category = appScreenTimeRequest.getCategory();
+        appScreenTime.duration = appScreenTimeRequest.getDuration();
+        return appScreenTime;
+    }
 }

--- a/src/main/java/dev/wetox/WetoxRESTful/screentime/AppScreenTimeRequest.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/screentime/AppScreenTimeRequest.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class AppScreenTimeRequest {
-    private String appName;
-    private String appCategory;
+    private String name;
+    private String category;
     private Double duration;
 }

--- a/src/main/java/dev/wetox/WetoxRESTful/screentime/AppScreenTimeRequest.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/screentime/AppScreenTimeRequest.java
@@ -9,5 +9,8 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class AppScreenTimeRequst {
+public class AppScreenTimeRequest {
+    private String appName;
+    private String appCategory;
+    private Double duration;
 }

--- a/src/main/java/dev/wetox/WetoxRESTful/screentime/AppScreenTimeRequst.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/screentime/AppScreenTimeRequst.java
@@ -1,0 +1,13 @@
+package dev.wetox.WetoxRESTful.screentime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AppScreenTimeRequst {
+}

--- a/src/main/java/dev/wetox/WetoxRESTful/screentime/AppScreenTimeResponse.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/screentime/AppScreenTimeResponse.java
@@ -13,4 +13,10 @@ public class AppScreenTimeResponse {
     private String name;
     private String category;
     private Double duration;
+
+    public AppScreenTimeResponse(AppScreenTime appScreenTime) {
+        this.name = appScreenTime.getName();
+        this.category = appScreenTime.getCategory();
+        this.duration = appScreenTime.getDuration();
+    }
 }

--- a/src/main/java/dev/wetox/WetoxRESTful/screentime/AppScreenTimeResponse.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/screentime/AppScreenTimeResponse.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class AppScreenTimeResponse {
-    private String appName;
-    private String appCategory;
+    private String name;
+    private String category;
     private Double duration;
 }

--- a/src/main/java/dev/wetox/WetoxRESTful/screentime/AppScreenTimeResponse.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/screentime/AppScreenTimeResponse.java
@@ -1,0 +1,13 @@
+package dev.wetox.WetoxRESTful.screentime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AppScreenTimeResponse {
+}

--- a/src/main/java/dev/wetox/WetoxRESTful/screentime/AppScreenTimeResponse.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/screentime/AppScreenTimeResponse.java
@@ -10,4 +10,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class AppScreenTimeResponse {
+    private String appName;
+    private String appCategory;
+    private Double duration;
 }

--- a/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTime.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTime.java
@@ -2,17 +2,19 @@ package dev.wetox.WetoxRESTful.screentime;
 
 import dev.wetox.WetoxRESTful.user.User;
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 import static jakarta.persistence.FetchType.LAZY;
 
 @Entity
-@Getter
-@Setter
+@Getter @Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class ScreenTime {
     @Id
     @GeneratedValue
@@ -25,8 +27,8 @@ public class ScreenTime {
 
     private LocalDateTime updatedDate;
 
-    private Double screenTimePerDays;
+    private Double totalDuration;
 
     @OneToMany(mappedBy = "screenTime")
-    private List<AppScreenTime> appScreenTimes;
+    private List<AppScreenTime> appScreenTimes = new ArrayList<>();
 }

--- a/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTime.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTime.java
@@ -8,13 +8,13 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+import static jakarta.persistence.CascadeType.PERSIST;
 import static jakarta.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
 
 @Entity
-@Getter @Setter
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
+@Getter
+@NoArgsConstructor(access = PROTECTED)
 public class ScreenTime {
     @Id
     @GeneratedValue
@@ -29,6 +29,27 @@ public class ScreenTime {
 
     private Double totalDuration;
 
-    @OneToMany(mappedBy = "screenTime")
+    @OneToMany(mappedBy = "screenTime", cascade = PERSIST)
     private List<AppScreenTime> appScreenTimes = new ArrayList<>();
+
+    public static ScreenTime build(User user, List<AppScreenTimeRequest> appScreenTimes) {
+        ScreenTime screenTime = new ScreenTime();
+        screenTime.user = user;
+        screenTime.updatedDate = LocalDateTime.now();
+
+        double totalDuration = 0.0;
+        for (AppScreenTimeRequest app: appScreenTimes) {
+            AppScreenTime appScreenTime = AppScreenTime.builder()
+                    .screenTime(screenTime)
+                    .name(app.getName())
+                    .category(app.getCategory())
+                    .duration(app.getDuration())
+                    .build();
+            totalDuration += app.getDuration();
+            screenTime.getAppScreenTimes().add(appScreenTime);
+        }
+        screenTime.totalDuration = totalDuration;
+
+        return screenTime;
+    }
 }

--- a/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTimeController.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTimeController.java
@@ -4,8 +4,6 @@ import dev.wetox.WetoxRESTful.user.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -17,14 +15,14 @@ public class ScreenTimeController {
     private final ScreenTimeService screenTimeService;
 
     @PostMapping
-    public ResponseEntity<List<AppScreenTimeResponse>> updateScreenTime(
+    public ResponseEntity<ScreenTimeResponse> updateScreenTime(
             @AuthenticationPrincipal User user,
-            @RequestBody List<AppScreenTimeRequst> request) {
+            @RequestBody List<AppScreenTimeRequest> request) {
         return ResponseEntity.ok(screenTimeService.updateScreenTime(user.getId(), request));
     }
 
     @GetMapping("/{userId}")
-    public ResponseEntity<List<AppScreenTimeResponse>> findScreenTime(
+    public ResponseEntity<ScreenTimeResponse> findScreenTime(
             @PathVariable Long userId
     ) {
         return ResponseEntity.ok(screenTimeService.findScreenTime(userId));

--- a/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTimeController.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTimeController.java
@@ -1,0 +1,32 @@
+package dev.wetox.WetoxRESTful.screentime;
+
+import dev.wetox.WetoxRESTful.user.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/screentime")
+@RequiredArgsConstructor
+public class ScreenTimeController {
+    private final ScreenTimeService screenTimeService;
+
+    @PostMapping
+    public ResponseEntity<List<AppScreenTimeResponse>> updateScreenTime(
+            @AuthenticationPrincipal User user,
+            @RequestBody List<AppScreenTimeRequst> request) {
+        return ResponseEntity.ok(screenTimeService.updateScreenTime(user.getId(), request));
+    }
+
+    @GetMapping("/{userId}")
+    public ResponseEntity<List<AppScreenTimeResponse>> findScreenTime(
+            @PathVariable Long userId
+    ) {
+        return ResponseEntity.ok(screenTimeService.findScreenTime(userId));
+    }
+}

--- a/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTimeController.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTimeController.java
@@ -22,7 +22,7 @@ public class ScreenTimeController {
     }
 
     @GetMapping("/{userId}")
-    public ResponseEntity<ScreenTimeResponse> findScreenTime(
+    public ResponseEntity<ScreenTimeResponse> retrieveScreenTime(
             @PathVariable Long userId
     ) {
         return ResponseEntity.ok(screenTimeService.retrieveScreenTime(userId));

--- a/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTimeController.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTimeController.java
@@ -25,6 +25,6 @@ public class ScreenTimeController {
     public ResponseEntity<ScreenTimeResponse> findScreenTime(
             @PathVariable Long userId
     ) {
-        return ResponseEntity.ok(screenTimeService.findScreenTime(userId));
+        return ResponseEntity.ok(screenTimeService.retrieveScreenTime(userId));
     }
 }

--- a/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTimeRepository.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTimeRepository.java
@@ -1,8 +1,14 @@
 package dev.wetox.WetoxRESTful.screentime;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface ScreenTimeRepository extends JpaRepository<ScreenTime, Long> {
+    @Query("SELECT s FROM ScreenTime s WHERE s.user.id = :userId ORDER BY s.updatedDate DESC")
+    Optional<ScreenTime> findLatestByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTimeRepository.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTimeRepository.java
@@ -7,9 +7,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-import java.util.Optional;
-
 @Repository
 public interface ScreenTimeRepository extends JpaRepository<ScreenTime, Long> {
     @Query("SELECT s FROM ScreenTime s WHERE s.user.id = :userId ORDER BY s.updatedDate DESC")

--- a/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTimeRepository.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTimeRepository.java
@@ -1,14 +1,17 @@
 package dev.wetox.WetoxRESTful.screentime;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface ScreenTimeRepository extends JpaRepository<ScreenTime, Long> {
     @Query("SELECT s FROM ScreenTime s WHERE s.user.id = :userId ORDER BY s.updatedDate DESC")
-    Optional<ScreenTime> findLatestByUserId(@Param("userId") Long userId);
+    Page<ScreenTime> findLatestByUserId(@Param("userId") Long userId, Pageable pageable);
 }

--- a/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTimeResponse.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTimeResponse.java
@@ -1,5 +1,6 @@
 package dev.wetox.WetoxRESTful.screentime;
 
+import dev.wetox.WetoxRESTful.user.User;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -17,4 +18,16 @@ public class ScreenTimeResponse {
     private LocalDateTime updatedDate;
     private Double totalDuration;
     private List<AppScreenTimeResponse> appScreenTimes;
+
+    public static ScreenTimeResponse build(User user, ScreenTime screenTime) {
+        return ScreenTimeResponse.builder()
+                .nickname(user.getNickname())
+                .updatedDate(screenTime.getUpdatedDate())
+                .totalDuration(screenTime.getTotalDuration())
+                .appScreenTimes(
+                        screenTime.getAppScreenTimes().stream()
+                                .map(AppScreenTimeResponse::new)
+                                .toList())
+                .build();
+    }
 }

--- a/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTimeResponse.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTimeResponse.java
@@ -1,0 +1,20 @@
+package dev.wetox.WetoxRESTful.screentime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ScreenTimeResponse {
+    private String nickname;
+    private LocalDateTime updatedDate;
+    private Double totalDuration;
+    private List<AppScreenTimeResponse> appScreenTimes;
+}

--- a/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTimeService.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTimeService.java
@@ -42,24 +42,12 @@ public class ScreenTimeService {
         }
         screenTime.setTotalDuration(totalDuration);
 
-        return buildScreenTimeResponse(user, screenTime);
+        return ScreenTimeResponse.build(user, screenTime);
     }
 
     public ScreenTimeResponse retrieveScreenTime(Long userId) {
         User user = userRepository.findById(userId).orElseThrow(MemberNotFoundException::new);
         ScreenTime screenTime = screenTimeRepository.findLatestByUserId(userId).orElseThrow(ScreenTimeNotFoundException::new);
-        return buildScreenTimeResponse(user, screenTime);
-    }
-
-    private ScreenTimeResponse buildScreenTimeResponse(User user, ScreenTime screenTime) {
-        return ScreenTimeResponse.builder()
-                .nickname(user.getNickname())
-                .updatedDate(screenTime.getUpdatedDate())
-                .totalDuration(screenTime.getTotalDuration())
-                .appScreenTimes(
-                        screenTime.getAppScreenTimes().stream()
-                                .map(AppScreenTimeResponse::new)
-                                .toList())
-                .build();
+        return ScreenTimeResponse.build(user, screenTime);
     }
 }

--- a/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTimeService.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTimeService.java
@@ -5,6 +5,9 @@ import dev.wetox.WetoxRESTful.exception.ScreenTimeNotFoundException;
 import dev.wetox.WetoxRESTful.user.User;
 import dev.wetox.WetoxRESTful.user.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,8 +32,12 @@ public class ScreenTimeService {
     public ScreenTimeResponse retrieveScreenTime(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(MemberNotFoundException::new);
-        ScreenTime screenTime = screenTimeRepository.findLatestByUserId(userId)
-                .orElseThrow(ScreenTimeNotFoundException::new);
-        return ScreenTimeResponse.build(user, screenTime);
+        Page<ScreenTime> screenTimePage
+                = screenTimeRepository.findLatestByUserId(userId, PageRequest.of(0, 1));
+        List<ScreenTime> screenTimes = screenTimePage.getContent();
+        if (screenTimes.isEmpty()) {
+            throw new ScreenTimeNotFoundException();
+        }
+        return ScreenTimeResponse.build(user, screenTimes.get(0));
     }
 }

--- a/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTimeService.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTimeService.java
@@ -22,26 +22,8 @@ public class ScreenTimeService {
     @Transactional
     public ScreenTimeResponse updateScreenTime(Long userId, List<AppScreenTimeRequest> request) {
         User user = userRepository.findById(userId).orElseThrow(MemberNotFoundException::new);
-
-        ScreenTime screenTime = new ScreenTime(); // builder를 사용하면 list 필드가 null이 됨;;
-        screenTime.setUser(user);
-        screenTime.setUpdatedDate(LocalDateTime.now());
+        ScreenTime screenTime = ScreenTime.build(user, request);
         screenTimeRepository.save(screenTime);
-
-        double totalDuration = 0.0;
-        for (AppScreenTimeRequest appRequest: request) {
-            AppScreenTime appScreenTime = AppScreenTime.builder()
-                    .screenTime(screenTime)
-                    .name(appRequest.getName())
-                    .category(appRequest.getCategory())
-                    .duration(appRequest.getDuration())
-                    .build();
-            totalDuration += appRequest.getDuration();
-            screenTime.getAppScreenTimes().add(appScreenTime);
-            appScreenTimeRepository.save(appScreenTime);
-        }
-        screenTime.setTotalDuration(totalDuration);
-
         return ScreenTimeResponse.build(user, screenTime);
     }
 

--- a/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTimeService.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTimeService.java
@@ -1,0 +1,21 @@
+package dev.wetox.WetoxRESTful.screentime;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ScreenTimeService {
+    @Transactional
+    public List<AppScreenTimeResponse> updateScreenTime(Long userId, List<AppScreenTimeRequst> request) {
+        return null;
+    }
+
+    public List<AppScreenTimeResponse> findScreenTime(Long userId) {
+        return null;
+    }
+}

--- a/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTimeService.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTimeService.java
@@ -7,7 +7,6 @@ import dev.wetox.WetoxRESTful.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTimeService.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTimeService.java
@@ -11,11 +11,11 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ScreenTimeService {
     @Transactional
-    public List<AppScreenTimeResponse> updateScreenTime(Long userId, List<AppScreenTimeRequst> request) {
+    public ScreenTimeResponse updateScreenTime(Long userId, List<AppScreenTimeRequest> request) {
         return null;
     }
 
-    public List<AppScreenTimeResponse> findScreenTime(Long userId) {
+    public ScreenTimeResponse findScreenTime(Long userId) {
         return null;
     }
 }

--- a/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTimeService.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTimeService.java
@@ -1,21 +1,65 @@
 package dev.wetox.WetoxRESTful.screentime;
 
+import dev.wetox.WetoxRESTful.exception.MemberNotFoundException;
+import dev.wetox.WetoxRESTful.exception.ScreenTimeNotFoundException;
+import dev.wetox.WetoxRESTful.user.User;
+import dev.wetox.WetoxRESTful.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class ScreenTimeService {
+    private final UserRepository userRepository;
+    private final ScreenTimeRepository screenTimeRepository;
+    private final AppScreenTimeRepository appScreenTimeRepository;
+
     @Transactional
     public ScreenTimeResponse updateScreenTime(Long userId, List<AppScreenTimeRequest> request) {
-        return null;
+        User user = userRepository.findById(userId).orElseThrow(MemberNotFoundException::new);
+
+        ScreenTime screenTime = new ScreenTime(); // builder를 사용하면 list 필드가 null이 됨;;
+        screenTime.setUser(user);
+        screenTime.setUpdatedDate(LocalDateTime.now());
+        screenTimeRepository.save(screenTime);
+
+        double totalDuration = 0.0;
+        for (AppScreenTimeRequest appRequest: request) {
+            AppScreenTime appScreenTime = AppScreenTime.builder()
+                    .screenTime(screenTime)
+                    .name(appRequest.getName())
+                    .category(appRequest.getCategory())
+                    .duration(appRequest.getDuration())
+                    .build();
+            totalDuration += appRequest.getDuration();
+            screenTime.getAppScreenTimes().add(appScreenTime);
+            appScreenTimeRepository.save(appScreenTime);
+        }
+        screenTime.setTotalDuration(totalDuration);
+
+        return buildScreenTimeResponse(user, screenTime);
     }
 
-    public ScreenTimeResponse findScreenTime(Long userId) {
-        return null;
+    public ScreenTimeResponse retrieveScreenTime(Long userId) {
+        User user = userRepository.findById(userId).orElseThrow(MemberNotFoundException::new);
+        ScreenTime screenTime = screenTimeRepository.findLatestByUserId(userId).orElseThrow(ScreenTimeNotFoundException::new);
+        return buildScreenTimeResponse(user, screenTime);
+    }
+
+    private ScreenTimeResponse buildScreenTimeResponse(User user, ScreenTime screenTime) {
+        return ScreenTimeResponse.builder()
+                .nickname(user.getNickname())
+                .updatedDate(screenTime.getUpdatedDate())
+                .totalDuration(screenTime.getTotalDuration())
+                .appScreenTimes(
+                        screenTime.getAppScreenTimes().stream()
+                                .map(AppScreenTimeResponse::new)
+                                .toList())
+                .build();
     }
 }

--- a/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTimeService.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTimeService.java
@@ -8,7 +8,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -17,19 +16,21 @@ import java.util.List;
 public class ScreenTimeService {
     private final UserRepository userRepository;
     private final ScreenTimeRepository screenTimeRepository;
-    private final AppScreenTimeRepository appScreenTimeRepository;
 
     @Transactional
     public ScreenTimeResponse updateScreenTime(Long userId, List<AppScreenTimeRequest> request) {
-        User user = userRepository.findById(userId).orElseThrow(MemberNotFoundException::new);
+        User user = userRepository.findById(userId)
+                .orElseThrow(MemberNotFoundException::new);
         ScreenTime screenTime = ScreenTime.build(user, request);
         screenTimeRepository.save(screenTime);
         return ScreenTimeResponse.build(user, screenTime);
     }
 
     public ScreenTimeResponse retrieveScreenTime(Long userId) {
-        User user = userRepository.findById(userId).orElseThrow(MemberNotFoundException::new);
-        ScreenTime screenTime = screenTimeRepository.findLatestByUserId(userId).orElseThrow(ScreenTimeNotFoundException::new);
+        User user = userRepository.findById(userId)
+                .orElseThrow(MemberNotFoundException::new);
+        ScreenTime screenTime = screenTimeRepository.findLatestByUserId(userId)
+                .orElseThrow(ScreenTimeNotFoundException::new);
         return ScreenTimeResponse.build(user, screenTime);
     }
 }

--- a/src/main/java/dev/wetox/WetoxRESTful/user/UserController.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/user/UserController.java
@@ -1,0 +1,23 @@
+package dev.wetox.WetoxRESTful.user;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/user")
+@RequiredArgsConstructor
+public class UserController {
+    private final UserService userService;
+
+    @GetMapping("/profile")
+    public ResponseEntity<UserResponse> retrieveProfile(
+            @AuthenticationPrincipal User user
+    ) {
+        return ResponseEntity.ok(userService.retrieveProfile(user.getId()));
+    }
+}

--- a/src/main/java/dev/wetox/WetoxRESTful/user/UserResponse.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/user/UserResponse.java
@@ -1,0 +1,15 @@
+package dev.wetox.WetoxRESTful.user;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserResponse {
+    private Long userId;
+    private String nickname;
+}

--- a/src/main/java/dev/wetox/WetoxRESTful/user/UserService.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/user/UserService.java
@@ -1,0 +1,22 @@
+package dev.wetox.WetoxRESTful.user;
+
+import dev.wetox.WetoxRESTful.exception.MemberNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+
+    public UserResponse retrieveProfile(Long userId) {
+        User user = userRepository.findById(userId).orElseThrow(MemberNotFoundException::new);
+        return UserResponse.builder()
+                .userId(user.getId())
+                .nickname(user.getNickname())
+                .build();
+    }
+}


### PR DESCRIPTION
## 작업 내용
스크린 타임을 업데이트하고 조회하는 API 엔드포인트와 서비스 코드 구현

## 엔드포인트

### POST /screentime
사용자의 스크린 타임 업데이트
### GET /screentime/{userId}
userId 사용자의 최신 스크린 타임을 조회

## 이후 진행
MVP를 위해 이용되는 스크린 타임 관련 통계량이 매우 제한적임. 추후 기능 확장을 대비할 필요가 있음.