### PR TITLE
feat / request :  친구 요청 도메인 생성 , 목록 조회 기능 추가 

### DIFF
--- a/src/main/java/dev/wetox/WetoxRESTful/Friend/Friend.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/Friend/Friend.java
@@ -1,0 +1,20 @@
+package dev.wetox.WetoxRESTful.Friend;
+
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class Friend {
+
+    @EmbeddedId
+    private FriendId id;
+
+}

--- a/src/main/java/dev/wetox/WetoxRESTful/Friend/FriendId.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/Friend/FriendId.java
@@ -1,0 +1,25 @@
+package dev.wetox.WetoxRESTful.Friend;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import lombok.*;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+@Embeddable
+@Builder
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class FriendId implements Serializable {
+
+    @GeneratedValue
+    private Long fromUserId;
+
+    @GeneratedValue
+    private Long toUserId;
+
+}

--- a/src/main/java/dev/wetox/WetoxRESTful/Friend/FriendRepository.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/Friend/FriendRepository.java
@@ -1,8 +1,8 @@
-package dev.wetox.WetoxRESTful.friendship;
+package dev.wetox.WetoxRESTful.Friend;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
+public interface FriendRepository extends JpaRepository<Friend, Long> {
 }

--- a/src/main/java/dev/wetox/WetoxRESTful/exception/RequestNotFoundException.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/exception/RequestNotFoundException.java
@@ -1,0 +1,7 @@
+package dev.wetox.WetoxRESTful.exception;
+
+public class RequestNotFoundException extends WetoxException {
+    public RequestNotFoundException(){
+        super(WetoxErorr.REQUEST_NOT_FOUND);
+    }
+}

--- a/src/main/java/dev/wetox/WetoxRESTful/request/ReqQueryDskRepsitory.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/request/ReqQueryDskRepsitory.java
@@ -1,0 +1,4 @@
+package dev.wetox.WetoxRESTful.request;
+
+public class ReqQueryDskRepsitory {
+}

--- a/src/main/java/dev/wetox/WetoxRESTful/request/Request.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/request/Request.java
@@ -1,0 +1,23 @@
+package dev.wetox.WetoxRESTful.request;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Entity
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class Request {
+
+    @Id
+    @Column(name = "request_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private RequestType requestType;
+
+}

--- a/src/main/java/dev/wetox/WetoxRESTful/request/RequestController.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/request/RequestController.java
@@ -1,0 +1,21 @@
+package dev.wetox.WetoxRESTful.request;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.support.RequestPartServletServerHttpRequest;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/request")
+public class RequestController {
+
+    private final RequestService requestService;
+
+    @GetMapping("{userId}")
+    public SelectReqByIdResponse selectReqById(@PathVariable Long userId){
+        return requestService.selectReqById(userId);
+    }
+}

--- a/src/main/java/dev/wetox/WetoxRESTful/request/RequestRepository.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/request/RequestRepository.java
@@ -1,0 +1,10 @@
+package dev.wetox.WetoxRESTful.request;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface RequestRepository extends JpaRepository<Request, Long> {
+}

--- a/src/main/java/dev/wetox/WetoxRESTful/request/RequestResponse.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/request/RequestResponse.java
@@ -1,0 +1,11 @@
+package dev.wetox.WetoxRESTful.request;
+
+
+public class RequestResponse {
+    public static SelectReqByIdResponse selectReqByIdResponse(Request request) {
+        return SelectReqByIdResponse.builder()
+                .requestId(request.getId())
+                .RequestType(request.getRequestType())
+                .build();
+    }
+}

--- a/src/main/java/dev/wetox/WetoxRESTful/request/RequestService.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/request/RequestService.java
@@ -1,0 +1,17 @@
+package dev.wetox.WetoxRESTful.request;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class RequestService {
+    private final RequestRepository RequestRepository;
+
+    public SelectReqByIdResponse selectReqById(Long id) {
+    }
+}
+

--- a/src/main/java/dev/wetox/WetoxRESTful/request/RequestType.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/request/RequestType.java
@@ -1,0 +1,7 @@
+package dev.wetox.WetoxRESTful.request;
+
+public enum RequestType {
+    FRIEND_REQUEST,
+    FRIEND_ACCEPT,
+    FRIEND_DECLINE
+}

--- a/src/main/java/dev/wetox/WetoxRESTful/request/SelectReqByIdResponse.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/request/SelectReqByIdResponse.java
@@ -1,0 +1,15 @@
+package dev.wetox.WetoxRESTful.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class SelectReqByIdResponse {
+    private Long requestId;
+    private RequestType RequestType;
+}

--- a/src/test/java/dev/wetox/WetoxRESTful/Friend/FriendTest.java
+++ b/src/test/java/dev/wetox/WetoxRESTful/Friend/FriendTest.java
@@ -1,0 +1,60 @@
+package dev.wetox.WetoxRESTful.Friend;
+
+import dev.wetox.WetoxRESTful.user.User;
+import dev.wetox.WetoxRESTful.user.UserRepository;
+import dev.wetox.WetoxRESTful.Friend.FriendRepository;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@Slf4j
+@SpringBootTest
+@NoArgsConstructor
+class FriendTest {
+
+    @Autowired
+    private FriendRepository friendRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private User fromUserId;
+    private User toUserId;
+
+
+    @BeforeEach
+    void beforeEach() {
+        fromUserId = userRepository.save(User.builder()
+                .nickname("from_id")
+                .build());
+
+        toUserId = userRepository.save(User.builder()
+                .nickname("to_id")
+                .build());
+        userRepository.save(fromUserId);
+        userRepository.save(toUserId);
+    }
+
+    @AfterEach
+    void afterEach(){
+        friendRepository.deleteAll();
+    }
+
+    @Test
+    void createFriendTest() {
+
+        FriendId friendId = FriendId.builder()
+                .fromUserId(fromUserId.getId())
+                .toUserId(toUserId.getId())
+                .build();
+
+        friendRepository.save(Friend.builder()
+                .id(friendId)
+                .build());
+
+    }
+}


### PR DESCRIPTION
### 작업 내용
기존의 친구 테이블과 분리하여 요청(알림)에 중점을 둔 request 테이블 생성
친구 요청 조회하는 API 엔드포인트 작성

### 엔드포인트
GET /request/{userId}
알림에서 userId의 친구 요청을 조회

### TODO
조회하는 API 서비스 구현
오류 메세지 추가해서 예외처리

### 이후 고려사항
조회 후 응답( 수락 / 거절 )에 대한 데이터 삭제 기능 추가 고려 