### PR TITLE
Feat/badge: 기본 엔드포인트 구현과 확장 가능한 설계

### DIFF
--- a/src/main/java/dev/wetox/WetoxRESTful/badge/Badge.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/badge/Badge.java
@@ -1,11 +1,10 @@
 package dev.wetox.WetoxRESTful.badge;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
+
+import static jakarta.persistence.EnumType.STRING;
 
 @Entity
 @Getter
@@ -17,5 +16,7 @@ public class Badge {
     private Long id;
 
     private String name;
-}
 
+    @Enumerated(STRING)
+    private BadgeResolver badgeResolver;
+}

--- a/src/main/java/dev/wetox/WetoxRESTful/badge/Badge.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/badge/Badge.java
@@ -2,7 +2,6 @@ package dev.wetox.WetoxRESTful.badge;
 
 import jakarta.persistence.*;
 import lombok.Getter;
-import lombok.Setter;
 
 import static jakarta.persistence.EnumType.STRING;
 

--- a/src/main/java/dev/wetox/WetoxRESTful/badge/Badge.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/badge/Badge.java
@@ -8,7 +8,6 @@ import static jakarta.persistence.EnumType.STRING;
 
 @Entity
 @Getter
-@Setter
 public class Badge {
     @Id
     @GeneratedValue
@@ -19,4 +18,11 @@ public class Badge {
 
     @Enumerated(STRING)
     private BadgeResolver badgeResolver;
+
+    public static Badge build(BadgeResolver badgeResolver) {
+        Badge badge = new Badge();
+        badge.name = badgeResolver.name();
+        badge.badgeResolver = badgeResolver;
+        return badge;
+    }
 }

--- a/src/main/java/dev/wetox/WetoxRESTful/badge/BadgeController.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/badge/BadgeController.java
@@ -18,14 +18,14 @@ public class BadgeController {
     private final BadgeService badgeService;
 
     @GetMapping
-    public ResponseEntity<List<UserBadgeResponse>> listRewardedBadge(
+    public ResponseEntity<List<BadgeResponse>> listRewardedBadge(
             @AuthenticationPrincipal User user
     ) {
         return ResponseEntity.ok(badgeService.listRewardedBadge(user.getId()));
     }
 
     @PostMapping
-    public ResponseEntity<List<UserBadgeResponse>> updateBadge(
+    public ResponseEntity<List<BadgeResponse>> updateBadge(
             @AuthenticationPrincipal User user
     ) {
         return ResponseEntity.ok(badgeService.updateBadge(user.getId()));

--- a/src/main/java/dev/wetox/WetoxRESTful/badge/BadgeController.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/badge/BadgeController.java
@@ -1,0 +1,33 @@
+package dev.wetox.WetoxRESTful.badge;
+
+import dev.wetox.WetoxRESTful.user.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/badge")
+@RequiredArgsConstructor
+public class BadgeController {
+    private final BadgeService badgeService;
+
+    @GetMapping
+    public ResponseEntity<List<UserBadgeResponse>> listRewardedBadge(
+            @AuthenticationPrincipal User user
+    ) {
+        return ResponseEntity.ok(badgeService.listRewardedBadge(user.getId()));
+    }
+
+    @PostMapping
+    public ResponseEntity<List<UserBadgeResponse>> updateBadge(
+            @AuthenticationPrincipal User user
+    ) {
+        return ResponseEntity.ok(badgeService.updateBadge(user.getId()));
+    }
+}

--- a/src/main/java/dev/wetox/WetoxRESTful/badge/BadgeDataLoader.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/badge/BadgeDataLoader.java
@@ -1,0 +1,20 @@
+package dev.wetox.WetoxRESTful.badge;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class BadgeDataLoader implements ApplicationListener<ContextRefreshedEvent> {
+    private final BadgeRepository badgeRepository;
+
+    @Override
+    public void onApplicationEvent(ContextRefreshedEvent event) {
+        for (BadgeResolver badgeResolver: BadgeResolver.values()) {
+            Badge badge = Badge.build(badgeResolver);
+            badgeRepository.save(badge);
+        }
+    }
+}

--- a/src/main/java/dev/wetox/WetoxRESTful/badge/BadgeResolvable.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/badge/BadgeResolvable.java
@@ -1,0 +1,7 @@
+package dev.wetox.WetoxRESTful.badge;
+
+import dev.wetox.WetoxRESTful.user.User;
+
+public interface BadgeResolvable {
+    boolean resolve(User user);
+}

--- a/src/main/java/dev/wetox/WetoxRESTful/badge/BadgeResolvable.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/badge/BadgeResolvable.java
@@ -3,5 +3,5 @@ package dev.wetox.WetoxRESTful.badge;
 import dev.wetox.WetoxRESTful.user.User;
 
 public interface BadgeResolvable {
-    boolean resolve(User user);
+    boolean resolve(User user, BadgeRepository badgeRepository, UserBadgeRepository userBadgeRepository);
 }

--- a/src/main/java/dev/wetox/WetoxRESTful/badge/BadgeResolver.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/badge/BadgeResolver.java
@@ -1,0 +1,29 @@
+package dev.wetox.WetoxRESTful.badge;
+
+import dev.wetox.WetoxRESTful.user.User;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum BadgeResolver {
+    NO_SCREEN_TIME_ONE_DAY(new BadgeResolvable() {
+        @Override
+        public boolean resolve(User user) {
+            return false;
+        }
+    }),
+    NO_SCREEN_TIME_ONE_WEEK(new BadgeResolvable() {
+        @Override
+        public boolean resolve(User user) {
+            return false;
+        }
+    }),
+    ;
+
+    private final BadgeResolvable badgeResolvable;
+
+    public boolean resolve(User user) {
+        return badgeResolvable.resolve(user);
+    }
+}

--- a/src/main/java/dev/wetox/WetoxRESTful/badge/BadgeResolver.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/badge/BadgeResolver.java
@@ -9,19 +9,19 @@ import lombok.RequiredArgsConstructor;
 public enum BadgeResolver {
     WELCOME(new BadgeResolvable() {
         @Override
-        public boolean resolve(User user) {
+        public boolean resolve(User user, BadgeRepository badgeRepository, UserBadgeRepository userBadgeRepository) {
             return true;
         }
     }),
     NO_SCREEN_TIME_ONE_DAY(new BadgeResolvable() {
         @Override
-        public boolean resolve(User user) {
+        public boolean resolve(User user, BadgeRepository badgeRepository, UserBadgeRepository userBadgeRepository) {
             return false;
         }
     }),
     NO_SCREEN_TIME_ONE_WEEK(new BadgeResolvable() {
         @Override
-        public boolean resolve(User user) {
+        public boolean resolve(User user, BadgeRepository badgeRepository, UserBadgeRepository userBadgeRepository) {
             return false;
         }
     }),
@@ -29,7 +29,7 @@ public enum BadgeResolver {
 
     private final BadgeResolvable badgeResolvable;
 
-    public boolean resolve(User user) {
-        return badgeResolvable.resolve(user);
+    public boolean resolve(User user, BadgeRepository badgeRepository, UserBadgeRepository userBadgeRepository) {
+        return badgeResolvable.resolve(user, badgeRepository, userBadgeRepository);
     }
 }

--- a/src/main/java/dev/wetox/WetoxRESTful/badge/BadgeResolver.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/badge/BadgeResolver.java
@@ -7,6 +7,12 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum BadgeResolver {
+    WELCOME(new BadgeResolvable() {
+        @Override
+        public boolean resolve(User user) {
+            return true;
+        }
+    }),
     NO_SCREEN_TIME_ONE_DAY(new BadgeResolvable() {
         @Override
         public boolean resolve(User user) {

--- a/src/main/java/dev/wetox/WetoxRESTful/badge/BadgeResponse.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/badge/BadgeResponse.java
@@ -1,0 +1,35 @@
+package dev.wetox.WetoxRESTful.badge;
+
+import dev.wetox.WetoxRESTful.user.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BadgeResponse {
+    private String badgeName;
+    private boolean isRewarded;
+    private LocalDateTime rewardedDate;
+
+    public static BadgeResponse buildRewarded(UserBadge userBadge) {
+        BadgeResponse badgeResponse = new BadgeResponse();
+        badgeResponse.badgeName = userBadge.getBadge().getName();
+        badgeResponse.isRewarded = true;
+        badgeResponse.rewardedDate = userBadge.getRewardedDate();
+        return badgeResponse;
+    }
+
+    public static BadgeResponse buildNotRewarded(Badge badge) {
+        BadgeResponse badgeResponse = new BadgeResponse();
+        badgeResponse.badgeName = badge.getName();
+        badgeResponse.isRewarded = false;
+        badgeResponse.rewardedDate = null;
+        return badgeResponse;
+    }
+}

--- a/src/main/java/dev/wetox/WetoxRESTful/badge/BadgeService.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/badge/BadgeService.java
@@ -1,0 +1,44 @@
+package dev.wetox.WetoxRESTful.badge;
+
+import dev.wetox.WetoxRESTful.exception.MemberNotFoundException;
+import dev.wetox.WetoxRESTful.user.User;
+import dev.wetox.WetoxRESTful.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class BadgeService {
+    private final UserRepository userRepository;
+    private final BadgeRepository badgeRepository;
+    private final UserBadgeRepository userBadgeRepository;
+
+    public List<UserBadgeResponse> listRewardedBadge(Long userId) {
+        User user = userRepository.findById(userId).orElseThrow(MemberNotFoundException::new);
+        List<UserBadge> userBadges = userBadgeRepository.findAllByUser(user);
+        return userBadges.stream().map(UserBadgeResponse::new).toList();
+    }
+
+    @Transactional
+    public List<UserBadgeResponse> updateBadge(Long userId) {
+        User user = userRepository.findById(userId).orElseThrow(MemberNotFoundException::new);
+        List<Badge> rewardedBadges = userBadgeRepository.findAllByUser(user).stream()
+                .map(UserBadge::getBadge)
+                .toList();
+        List<Badge> notRewardedBadges = badgeRepository.findAll().stream()
+                .filter(badge -> !rewardedBadges.contains(badge))
+                .toList();
+        for (Badge badge: notRewardedBadges) {
+            if (!badge.getBadgeResolver().resolve(user)) {
+                continue;
+            }
+            UserBadge userBadge = UserBadge.build(user, badge);
+            userBadgeRepository.save(userBadge);
+        }
+        return listRewardedBadge(userId);
+    }
+}

--- a/src/main/java/dev/wetox/WetoxRESTful/badge/BadgeService.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/badge/BadgeService.java
@@ -8,7 +8,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.function.Function;
 import java.util.stream.Stream;
 
 @Service

--- a/src/main/java/dev/wetox/WetoxRESTful/badge/BadgeService.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/badge/BadgeService.java
@@ -47,7 +47,7 @@ public class BadgeService {
                 .filter(badge -> !rewardedBadges.contains(badge))
                 .toList();
         for (Badge badge: notRewardedBadges) {
-            if (!badge.getBadgeResolver().resolve(user)) {
+            if (!badge.getBadgeResolver().resolve(user, badgeRepository, userBadgeRepository)) {
                 continue;
             }
             UserBadge userBadge = UserBadge.build(user, badge);

--- a/src/main/java/dev/wetox/WetoxRESTful/badge/UserBadge.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/badge/UserBadge.java
@@ -3,7 +3,6 @@ package dev.wetox.WetoxRESTful.badge;
 import dev.wetox.WetoxRESTful.user.User;
 import jakarta.persistence.*;
 import lombok.Getter;
-import lombok.Setter;
 
 import java.time.LocalDateTime;
 
@@ -11,7 +10,6 @@ import static jakarta.persistence.FetchType.LAZY;
 
 @Entity
 @Getter
-@Setter
 public class UserBadge {
     @Id
     @GeneratedValue
@@ -24,8 +22,16 @@ public class UserBadge {
 
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "badge_id")
-    private User badge;
+    private Badge badge;
 
-    private LocalDateTime rewaredDate;
+    private LocalDateTime rewardedDate;
+
+    public static UserBadge build(User user, Badge badge) {
+        UserBadge userBadge = new UserBadge();
+        userBadge.user = user;
+        userBadge.badge = badge;
+        userBadge.rewardedDate = LocalDateTime.now();
+        return userBadge;
+    }
 }
 

--- a/src/main/java/dev/wetox/WetoxRESTful/badge/UserBadgeRepository.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/badge/UserBadgeRepository.java
@@ -1,8 +1,15 @@
 package dev.wetox.WetoxRESTful.badge;
 
+import dev.wetox.WetoxRESTful.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface UserBadgeRepository extends JpaRepository<UserBadge, Long> {
+    @Query("SELECT ub FROM UserBadge ub WHERE ub.user = :user")
+    List<UserBadge> findAllByUser(@Param("user") User user);
 }

--- a/src/main/java/dev/wetox/WetoxRESTful/badge/UserBadgeResponse.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/badge/UserBadgeResponse.java
@@ -1,0 +1,22 @@
+package dev.wetox.WetoxRESTful.badge;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserBadgeResponse {
+    private String badgeName;
+    private LocalDateTime rewardedDate;
+
+    public UserBadgeResponse(UserBadge userBadge) {
+        this.badgeName = userBadge.getBadge().getName();
+        this.rewardedDate = userBadge.getRewardedDate();
+    }
+}


### PR DESCRIPTION
## 작업 내용
이슈 #4:  배지 리스트 조회와 업데이트 API 엔드포인트 구현
요구사항 반영하여 배지 리스트 조회와 업데이트 요청 모두 구현함.
각 배지 별 검증 로직은 지속적으로 추가 예정.
![image](https://github.com/GDSC-Wetox/WetoxRESTful/assets/70203010/c61b2323-b1f0-4436-b44a-20920984a3f1)

## 검증 로직 추가
BadgeResolver 열거형에 원소를 추가 -> 새로운 배지와 검증 로직. 이때 추가한 원소의 이름이 배지의 이름이 되며, BadgeResolvable를 구현한 익명 객체는 검증 로직이 된다.
![image](https://github.com/GDSC-Wetox/WetoxRESTful/assets/70203010/af4cf1e6-feb7-410d-b0b1-b0985207e4d5)
