### PR TITLE
Feat/screentime: 존재하지 않는 스크린 타임 조회에 대한 에러 응답 폐기

### DIFF
--- a/src/main/java/dev/wetox/WetoxRESTful/friendship/FriendshipService.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/friendship/FriendshipService.java
@@ -97,12 +97,11 @@ public class FriendshipService {
             Page<ScreenTime> screenTimePage
                     = screenTimeRepository.findLatestByUserId(friendId, PageRequest.of(0, 1));
             List<ScreenTime> screenTimes = screenTimePage.getContent();
-                if (screenTimes.isEmpty()) {
-                    throw new ScreenTimeNotFoundException();
-                }
-
-            ScreenTime latestScreenTime = screenTimes.get(0);
-            double totalDuration = latestScreenTime.getTotalDuration();
+            double totalDuration = 0L;
+            if (!screenTimes.isEmpty()) {
+                ScreenTime latestScreenTime = screenTimes.get(0);
+                totalDuration = latestScreenTime.getTotalDuration();
+            }
 
             responses.add(FriendshipListResponse.builder()
                     .userId(friendship.getFrom().getId())

--- a/src/main/java/dev/wetox/WetoxRESTful/screentime/CategoryScreenTime.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/screentime/CategoryScreenTime.java
@@ -23,7 +23,7 @@ public class CategoryScreenTime {
     @Enumerated(STRING)
     private Category category;
 
-    private Double duration;
+    private Long duration;
 
     public static CategoryScreenTime build(ScreenTime screenTime, CategoryScreenTimeRequest categoryScreenTimeRequest) {
         CategoryScreenTime categoryScreenTime = new CategoryScreenTime();

--- a/src/main/java/dev/wetox/WetoxRESTful/screentime/CategoryScreenTimeRequest.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/screentime/CategoryScreenTimeRequest.java
@@ -11,5 +11,5 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class CategoryScreenTimeRequest {
     private Category category;
-    private Double duration;
+    private Long duration;
 }

--- a/src/main/java/dev/wetox/WetoxRESTful/screentime/CategoryScreenTimeResponse.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/screentime/CategoryScreenTimeResponse.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class CategoryScreenTimeResponse {
     private Category category;
-    private Double duration;
+    private Long duration;
 
     public CategoryScreenTimeResponse(CategoryScreenTime categoryScreenTime) {
         this.category = categoryScreenTime.getCategory();

--- a/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTime.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTime.java
@@ -27,7 +27,7 @@ public class ScreenTime {
 
     private LocalDateTime updatedDate;
 
-    private Double totalDuration = 0.0;
+    private Long totalDuration = 0L;
 
     @OneToMany(mappedBy = "screenTime", cascade = ALL)
     private List<CategoryScreenTime> categoryScreenTimes = new ArrayList<>();
@@ -40,7 +40,7 @@ public class ScreenTime {
             screenTime.categoryScreenTimes.add(CategoryScreenTime.build(screenTime, categoryScreenTime));
         }
         screenTime.totalDuration = screenTime.categoryScreenTimes.stream()
-                .mapToDouble(CategoryScreenTime::getDuration)
+                .mapToLong(CategoryScreenTime::getDuration)
                 .sum();
         return screenTime;
     }

--- a/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTime.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTime.java
@@ -27,7 +27,7 @@ public class ScreenTime {
 
     private LocalDateTime updatedDate;
 
-    private Double totalDuration;
+    private Double totalDuration = 0.0;
 
     @OneToMany(mappedBy = "screenTime", cascade = ALL)
     private List<CategoryScreenTime> categoryScreenTimes = new ArrayList<>();

--- a/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTimeResponse.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTimeResponse.java
@@ -16,7 +16,7 @@ import java.util.List;
 public class ScreenTimeResponse {
     private String nickname;
     private LocalDateTime updatedDate;
-    private Double totalDuration;
+    private Long totalDuration;
     private List<CategoryScreenTimeResponse> categoryScreenTimes;
 
     public static ScreenTimeResponse build(User user, ScreenTime screenTime) {

--- a/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTimeService.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTimeService.java
@@ -35,7 +35,8 @@ public class ScreenTimeService {
                 = screenTimeRepository.findLatestByUserId(userId, PageRequest.of(0, 1));
         List<ScreenTime> screenTimes = screenTimePage.getContent();
         if (screenTimes.isEmpty()) {
-            throw new ScreenTimeNotFoundException();
+//            throw new ScreenTimeNotFoundException();
+            return ScreenTimeResponse.build(user, new ScreenTime());
         }
         return ScreenTimeResponse.build(user, screenTimes.get(0));
     }

--- a/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTimeService.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTimeService.java
@@ -1,7 +1,6 @@
 package dev.wetox.WetoxRESTful.screentime;
 
 import dev.wetox.WetoxRESTful.exception.MemberNotFoundException;
-import dev.wetox.WetoxRESTful.exception.ScreenTimeNotFoundException;
 import dev.wetox.WetoxRESTful.user.User;
 import dev.wetox.WetoxRESTful.user.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -35,7 +34,6 @@ public class ScreenTimeService {
                 = screenTimeRepository.findLatestByUserId(userId, PageRequest.of(0, 1));
         List<ScreenTime> screenTimes = screenTimePage.getContent();
         if (screenTimes.isEmpty()) {
-//            throw new ScreenTimeNotFoundException();
             return ScreenTimeResponse.build(user, new ScreenTime());
         }
         return ScreenTimeResponse.build(user, screenTimes.get(0));


### PR DESCRIPTION
## 작업 내용
resolve #14 
친구 리스트 조회에서 친구의 스크린 타임이 존재하지 않으면 전체 리스트 조회가 불가능했던 오류를 해결.
존재하지 않는 스크린 타임에 대한 조회 요청에 전체 스크린 타임 지속 시간이 0으로 표현 되도록 수정. 