### PR TITLE
refactor: JJWT 라이브러리의 JWK, JWK Set 파싱 기능 이용

### DIFF
--- a/src/main/java/dev/wetox/WetoxRESTful/auth/KakaoOIDCService.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/auth/KakaoOIDCService.java
@@ -3,17 +3,14 @@ package dev.wetox.WetoxRESTful.auth;
 import dev.wetox.WetoxRESTful.exception.OIDCInvalidPublicKeyIdException;
 import dev.wetox.WetoxRESTful.exception.OIDCValidationFailException;
 import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.JwkSet;
+import io.jsonwebtoken.security.Jwks;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
-import java.math.BigInteger;
 import java.security.Key;
-import java.security.KeyFactory;
 import java.security.PublicKey;
-import java.security.spec.RSAPublicKeySpec;
-import java.util.Base64;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 @Service
@@ -51,35 +48,11 @@ public class KakaoOIDCService {
 
     private void generatePublicKeys() {
         publicKeys = new HashMap<>();
-        List<KakaoOIDCJwkResponse> jwks = requestJwks();
-        jwks.forEach(jwk -> publicKeys.put(jwk.getKid(), generatePublicKey(jwk)));
-    }
-
-    private List<KakaoOIDCJwkResponse> requestJwks() {
         RestTemplate restTemplate = new RestTemplate();
-        KakaoOIDCJwksResponse response = restTemplate
-                .getForObject("https://kauth.kakao.com/.well-known/jwks.json", KakaoOIDCJwksResponse.class);
-        return response.getKeys();
-    }
-
-    private PublicKey generatePublicKey(KakaoOIDCJwkResponse jwk) {
-        try {
-            BigInteger modulus = decodeBase64urlUint(jwk.getN());
-            BigInteger exponent = decodeBase64urlUint(jwk.getE());
-            RSAPublicKeySpec rsaPublicKeySpec = new RSAPublicKeySpec(modulus, exponent);
-            KeyFactory keyFactory = KeyFactory.getInstance("RSA");
-            return keyFactory.generatePublic(rsaPublicKeySpec);
-        } catch (Exception e) {
-            throw new OIDCInvalidPublicKeyIdException();
-        }
-    }
-
-    private BigInteger decodeBase64urlUint(String base64urlUintEncoded) {
-        String padded = base64urlUintEncoded.length() % 4 == 0 ?
-                base64urlUintEncoded :
-                base64urlUintEncoded + "====".substring(base64urlUintEncoded.length() % 4);
-        String base64Encoded = padded.replace('_', '/').replace('-', '+');
-        byte[] decoded = Base64.getDecoder().decode(base64Encoded);
-        return new BigInteger(1, decoded);
+        String jwksResponse = restTemplate.getForObject("https://kauth.kakao.com/.well-known/jwks.json", String.class);
+        JwkSet jwks = Jwks.setParser()
+                .build()
+                .parse(jwksResponse);
+        jwks.forEach(jwk -> publicKeys.put(jwk.getId(), (PublicKey)jwk.toKey()));
     }
 }


### PR DESCRIPTION
## 작업 내용
기존의 구현은 OIDC 토큰 검증 과정에서 JWK Set으로부터 공개키 정보를 직접 디코딩하여 JCA PublicKey 객체를 생성해 이용했다. 하지만 해당 기능은 JJWT 라이브러리의 JWK 파싱 기능으로 이미 제공되고 있었고, 따라서 기존의 구현을 삭제하고 라이브러리의 기능을 이용하도록 변경했다.