### PR TITLE
modify: userId 프로필 조회 기능 추가와 친구 리스트 응답 생성, 프로필 응답 생성 리팩토링

### DIFF
--- a/src/main/java/dev/wetox/WetoxRESTful/friendship/FriendshipController.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/friendship/FriendshipController.java
@@ -1,6 +1,7 @@
 package dev.wetox.WetoxRESTful.friendship;
 
 import dev.wetox.WetoxRESTful.user.User;
+import dev.wetox.WetoxRESTful.user.UserResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -31,7 +32,7 @@ public class FriendshipController {
     }
 
     @GetMapping()
-    public ResponseEntity<List<FriendshipListResponse>> getFriendship(@AuthenticationPrincipal User user) {
+    public ResponseEntity<List<UserResponse>> getFriendship(@AuthenticationPrincipal User user) {
         return ResponseEntity.ok(friendshipService.getFriendShip(user.getId()));
     }
 

--- a/src/main/java/dev/wetox/WetoxRESTful/friendship/FriendshipService.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/friendship/FriendshipService.java
@@ -3,20 +3,16 @@ package dev.wetox.WetoxRESTful.friendship;
 import dev.wetox.WetoxRESTful.exception.FriendshipExistException;
 import dev.wetox.WetoxRESTful.exception.FriendshipRequestNotFoundException;
 import dev.wetox.WetoxRESTful.exception.NotRequestMyselfException;
-import dev.wetox.WetoxRESTful.image.ImageService;
-import dev.wetox.WetoxRESTful.screentime.ScreenTime;
-import dev.wetox.WetoxRESTful.screentime.ScreenTimeRepository;
 import dev.wetox.WetoxRESTful.user.User;
 import dev.wetox.WetoxRESTful.user.UserRepository;
+import dev.wetox.WetoxRESTful.user.UserResponse;
+import dev.wetox.WetoxRESTful.user.UserService;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -29,8 +25,7 @@ public class FriendshipService {
 
     private final FriendshipRepository friendshipRepository;
     private final UserRepository userRepository;
-    private final ScreenTimeRepository screenTimeRepository;
-    private final ImageService imageService;
+    private final UserService userService;
 
     //친구 관계 요청
     @Transactional
@@ -89,30 +84,12 @@ public class FriendshipService {
 
     //전체 친구 목록 조회
     @Transactional(readOnly = true)
-    public List<FriendshipListResponse> getFriendShip(Long userId) {
+    public List<UserResponse> getFriendShip(Long userId) {
         List<Friendship> friendShips = friendshipRepository.findByToIdAndStatus(userId, FriendshipStatus.ACCEPT);
-        List<FriendshipListResponse> responses = new ArrayList<>();
-
-        for (Friendship friendship : friendShips) {
-            Long friendId = friendship.getFrom().getId();
-            Page<ScreenTime> screenTimePage
-                    = screenTimeRepository.findLatestByUserId(friendId, PageRequest.of(0, 1));
-            List<ScreenTime> screenTimes = screenTimePage.getContent();
-            Long totalDuration = 0L;
-            if (!screenTimes.isEmpty()) {
-                ScreenTime latestScreenTime = screenTimes.get(0);
-                totalDuration = latestScreenTime.getTotalDuration();
-            }
-
-            responses.add(FriendshipListResponse.builder()
-                    .userId(friendship.getFrom().getId())
-                    .nickname(friendship.getFrom().getNickname())
-                    .totalDuration(totalDuration)
-                    .profileImage(imageService.getImageUrl(friendship.getFrom().getProfileImageUUID()))
-                    .build());
-
-        }
-        return responses;
+        return friendShips.stream()
+                .map(friendship -> friendship.getFrom().getId())
+                .map(userService::retrieveProfile)
+                .toList();
     }
 
     //나에게 친구요청을 보낸 친구목록

--- a/src/main/java/dev/wetox/WetoxRESTful/user/UserController.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/user/UserController.java
@@ -1,10 +1,12 @@
 package dev.wetox.WetoxRESTful.user;
 
 import lombok.RequiredArgsConstructor;
+import org.apache.coyote.Response;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,5 +21,12 @@ public class UserController {
             @AuthenticationPrincipal User user
     ) {
         return ResponseEntity.ok(userService.retrieveProfile(user.getId()));
+    }
+
+    @GetMapping("/profile/{userId}")
+    public ResponseEntity<UserResponse> retrieveProfileByUserId(
+            @PathVariable Long userId
+    ) {
+        return ResponseEntity.ok(userService.retrieveProfile(userId));
     }
 }

--- a/src/main/java/dev/wetox/WetoxRESTful/user/UserResponse.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/user/UserResponse.java
@@ -12,5 +12,6 @@ import lombok.NoArgsConstructor;
 public class UserResponse {
     private Long userId;
     private String nickname;
+    private Long totalDuration;
     private String profileImage;
 }

--- a/src/main/java/dev/wetox/WetoxRESTful/user/UserService.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/user/UserService.java
@@ -2,9 +2,17 @@ package dev.wetox.WetoxRESTful.user;
 
 import dev.wetox.WetoxRESTful.exception.MemberNotFoundException;
 import dev.wetox.WetoxRESTful.image.ImageService;
+import dev.wetox.WetoxRESTful.screentime.ScreenTime;
+import dev.wetox.WetoxRESTful.screentime.ScreenTimeRepository;
+import dev.wetox.WetoxRESTful.screentime.ScreenTimeResponse;
+import dev.wetox.WetoxRESTful.screentime.ScreenTimeService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @Transactional(readOnly = true)
@@ -12,12 +20,15 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
     private final UserRepository userRepository;
     private final ImageService imageService;
+    private final ScreenTimeService screenTimeService;
 
     public UserResponse retrieveProfile(Long userId) {
         User user = userRepository.findById(userId).orElseThrow(MemberNotFoundException::new);
+        ScreenTimeResponse screenTimeResponse = screenTimeService.retrieveScreenTime(userId);
         return UserResponse.builder()
                 .userId(user.getId())
                 .nickname(user.getNickname())
+                .totalDuration(screenTimeResponse.getTotalDuration())
                 .profileImage(imageService.getImageUrl(user.getProfileImageUUID()))
                 .build();
     }


### PR DESCRIPTION
resolve Issue #24 - 3

- UserController에 사용자 아이디로 프로필 조회하는 API 엔드포인트 추가
- 친구 리스트 생성 시 UserService의 retrieveProfile 메소드 이용, 컬렉션 스트림 이용해 코드 단순화
- UserService의 retrieveProfile에서 retrieveScreenTime을 이용해 최신 스크린 타임 조회하도록 수정