### PR TITLE
add: 동일한 닉네임으로 등록된 사용자 존재 질의 API

### DIFF
--- a/src/main/java/dev/wetox/WetoxRESTful/auth/AuthenticationController.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/auth/AuthenticationController.java
@@ -1,7 +1,6 @@
 package dev.wetox.WetoxRESTful.auth;
 
-import dev.wetox.WetoxRESTful.user.OAuthProvider;
-import dev.wetox.WetoxRESTful.user.UserRepository;
+import dev.wetox.WetoxRESTful.user.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -12,6 +11,7 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 public class AuthenticationController {
     private final AuthenticationService authenticationService;
+    private final UserService userService;
 
     private UserRepository userRepository;
 
@@ -44,5 +44,12 @@ public class AuthenticationController {
     @GetMapping("/valid")
     public ResponseEntity<String> valid() {
         return ResponseEntity.ok("OK");
+    }
+
+    @GetMapping("/valid/nickname")
+    public ResponseEntity<UserDuplicatedConfirmResponse> checkNicknameDuplicated(
+            @RequestBody UserDuplicatedConfirmRequest request
+    ) {
+        return ResponseEntity.ok(userService.checkNicknameDuplicated(request.getNickname()));
     }
 }

--- a/src/main/java/dev/wetox/WetoxRESTful/config/SecurityConfig.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/config/SecurityConfig.java
@@ -29,6 +29,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(request -> request
                         .requestMatchers("/auth/register").permitAll()
                         .requestMatchers("/auth/token").permitAll()
+                        .requestMatchers("/auth/valid/**").permitAll()
                         .anyRequest().authenticated())
                 .sessionManagement(session -> session.sessionCreationPolicy(STATELESS))
                 .authenticationProvider(authenticationProvider)

--- a/src/main/java/dev/wetox/WetoxRESTful/user/UserDuplicatedConfirmRequest.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/user/UserDuplicatedConfirmRequest.java
@@ -1,0 +1,14 @@
+package dev.wetox.WetoxRESTful.user;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserDuplicatedConfirmRequest {
+    private String nickname;
+}

--- a/src/main/java/dev/wetox/WetoxRESTful/user/UserDuplicatedConfirmResponse.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/user/UserDuplicatedConfirmResponse.java
@@ -1,0 +1,20 @@
+package dev.wetox.WetoxRESTful.user;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserDuplicatedConfirmResponse {
+    private boolean existed;
+
+    public static UserDuplicatedConfirmResponse build(boolean present) {
+        UserDuplicatedConfirmResponse response = new UserDuplicatedConfirmResponse();
+        response.setExisted(present);
+        return response;
+    }
+}

--- a/src/main/java/dev/wetox/WetoxRESTful/user/UserService.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/user/UserService.java
@@ -2,17 +2,13 @@ package dev.wetox.WetoxRESTful.user;
 
 import dev.wetox.WetoxRESTful.exception.MemberNotFoundException;
 import dev.wetox.WetoxRESTful.image.ImageService;
-import dev.wetox.WetoxRESTful.screentime.ScreenTime;
-import dev.wetox.WetoxRESTful.screentime.ScreenTimeRepository;
 import dev.wetox.WetoxRESTful.screentime.ScreenTimeResponse;
 import dev.wetox.WetoxRESTful.screentime.ScreenTimeService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
+import java.util.Optional;
 
 @Service
 @Transactional(readOnly = true)
@@ -31,5 +27,10 @@ public class UserService {
                 .totalDuration(screenTimeResponse.getTotalDuration())
                 .profileImage(imageService.getImageUrl(user.getProfileImageUUID()))
                 .build();
+    }
+
+    public UserDuplicatedConfirmResponse checkNicknameDuplicated(String nickname) {
+        Optional<User> user = userRepository.findByNickname(nickname);
+        return UserDuplicatedConfirmResponse.build(user.isPresent());
     }
 }


### PR DESCRIPTION
## 작업 내용
resolve Issue #25 

새로 등록하고자 하는 사용자 닉네임이 이미 등록되었는지 확인하고자 할 때 이용.

request:
GET /auth/valid/nickname
```json
{
  "nickname": String
}
```

response:
```json
{
  "existed": Boolean
}
```