### PR TITLE
!HOTFIX: MemberNotFoundException 이름 변경 -> UserNotFoundException

### DIFF
--- a/src/main/java/dev/wetox/WetoxRESTful/auth/AuthenticationService.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/auth/AuthenticationService.java
@@ -1,6 +1,6 @@
 package dev.wetox.WetoxRESTful.auth;
 
-import dev.wetox.WetoxRESTful.exception.MemberNotFoundException;
+import dev.wetox.WetoxRESTful.exception.UserNotFoundException;
 import dev.wetox.WetoxRESTful.exception.UserRegisterDuplicateException;
 import dev.wetox.WetoxRESTful.image.ImageService;
 import dev.wetox.WetoxRESTful.jwt.JwtService;
@@ -60,7 +60,7 @@ public class AuthenticationService {
     public AuthenticationResponse authenticate(OAuthProvider oAuthProvider, String openId) {
         String subject = kakaoOIDCService.extractSubject(openId);
         User user = userRepository.findByOauthProviderAndOauthSubject(oAuthProvider, subject)
-                .orElseThrow(MemberNotFoundException::new);
+                .orElseThrow(UserNotFoundException::new);
 
         authenticationManager.authenticate(
                 new UsernamePasswordAuthenticationToken(

--- a/src/main/java/dev/wetox/WetoxRESTful/badge/BadgeService.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/badge/BadgeService.java
@@ -1,6 +1,6 @@
 package dev.wetox.WetoxRESTful.badge;
 
-import dev.wetox.WetoxRESTful.exception.MemberNotFoundException;
+import dev.wetox.WetoxRESTful.exception.UserNotFoundException;
 import dev.wetox.WetoxRESTful.user.User;
 import dev.wetox.WetoxRESTful.user.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -19,7 +19,7 @@ public class BadgeService {
     private final UserBadgeRepository userBadgeRepository;
 
     public List<BadgeResponse> listRewardedBadge(Long userId) {
-        User user = userRepository.findById(userId).orElseThrow(MemberNotFoundException::new);
+        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
         List<Badge> rewardedBadges = userBadgeRepository.findAllByUser(user).stream()
                 .map(UserBadge::getBadge)
                 .toList();
@@ -38,7 +38,7 @@ public class BadgeService {
 
     @Transactional
     public List<BadgeResponse> updateBadge(Long userId) {
-        User user = userRepository.findById(userId).orElseThrow(MemberNotFoundException::new);
+        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
         List<Badge> rewardedBadges = userBadgeRepository.findAllByUser(user).stream()
                 .map(UserBadge::getBadge)
                 .toList();

--- a/src/main/java/dev/wetox/WetoxRESTful/exception/MemberNotFoundException.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/exception/MemberNotFoundException.java
@@ -1,9 +1,0 @@
-package dev.wetox.WetoxRESTful.exception;
-
-import static dev.wetox.WetoxRESTful.exception.WetoxErorr.MEMBER_NOT_FOUND;
-
-public class MemberNotFoundException extends WetoxException {
-    public MemberNotFoundException() {
-        super(MEMBER_NOT_FOUND);
-    }
-}

--- a/src/main/java/dev/wetox/WetoxRESTful/exception/UserNotFoundException.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/exception/UserNotFoundException.java
@@ -1,0 +1,9 @@
+package dev.wetox.WetoxRESTful.exception;
+
+import static dev.wetox.WetoxRESTful.exception.WetoxErorr.USER_NOT_FOUND;
+
+public class UserNotFoundException extends WetoxException {
+    public UserNotFoundException() {
+        super(USER_NOT_FOUND);
+    }
+}

--- a/src/main/java/dev/wetox/WetoxRESTful/exception/WetoxErorr.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/exception/WetoxErorr.java
@@ -10,7 +10,7 @@ import static org.springframework.http.HttpStatus.*;
 @RequiredArgsConstructor
 public enum WetoxErorr {
     DUPLICATED_USER_REGISTER("중복된 사용자 등록입니다.", BAD_REQUEST),
-    MEMBER_NOT_FOUND("존재하지 않는 사용자입니다.", NOT_FOUND),
+    USER_NOT_FOUND("존재하지 않는 사용자입니다.", NOT_FOUND),
     SCREEN_TIME_NOT_FOUND("스크린 타임이 존재하지 않습니다.", NOT_FOUND),
 
     OIDC_VALIDATION_FAIL("OIDC 인증에 실패했습니다.", UNAUTHORIZED),

--- a/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTimeService.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTimeService.java
@@ -1,6 +1,6 @@
 package dev.wetox.WetoxRESTful.screentime;
 
-import dev.wetox.WetoxRESTful.exception.MemberNotFoundException;
+import dev.wetox.WetoxRESTful.exception.UserNotFoundException;
 import dev.wetox.WetoxRESTful.user.User;
 import dev.wetox.WetoxRESTful.user.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +21,7 @@ public class ScreenTimeService {
     @Transactional
     public ScreenTimeResponse updateScreenTime(Long userId, List<CategoryScreenTimeRequest> request) {
         User user = userRepository.findById(userId)
-                .orElseThrow(MemberNotFoundException::new);
+                .orElseThrow(UserNotFoundException::new);
         ScreenTime screenTime = ScreenTime.build(user, request);
         screenTimeRepository.save(screenTime);
         return ScreenTimeResponse.build(user, screenTime);
@@ -29,7 +29,7 @@ public class ScreenTimeService {
 
     public ScreenTimeResponse retrieveScreenTime(Long userId) {
         User user = userRepository.findById(userId)
-                .orElseThrow(MemberNotFoundException::new);
+                .orElseThrow(UserNotFoundException::new);
         Page<ScreenTime> screenTimePage
                 = screenTimeRepository.findLatestByUserId(userId, PageRequest.of(0, 1));
         List<ScreenTime> screenTimes = screenTimePage.getContent();

--- a/src/main/java/dev/wetox/WetoxRESTful/user/UserService.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/user/UserService.java
@@ -1,6 +1,6 @@
 package dev.wetox.WetoxRESTful.user;
 
-import dev.wetox.WetoxRESTful.exception.MemberNotFoundException;
+import dev.wetox.WetoxRESTful.exception.UserNotFoundException;
 import dev.wetox.WetoxRESTful.image.ImageService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,7 +20,7 @@ public class UserService {
     private final ImageService imageService;
 
     public UserResponse retrieveProfile(Long userId) {
-        User user = userRepository.findById(userId).orElseThrow(MemberNotFoundException::new);
+        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
         return UserResponse.builder()
                 .userId(user.getId())
                 .nickname(user.getNickname())


### PR DESCRIPTION
## 작업내용
resolve Issue #5 
사용자가 존재하지 않은 경우에 발생했던 예외 MemberNotFoundException의 이름을 UserNotFoundException으로 변경!
앞으로 작성하는 코드에서 사용자가 존재하지 않는 경우에는 `UserNotFoundException` 이용할 것!!