### PR TITLE
!HOTFIX: 사용자 프로필 응답 중 totalDuration 필드 누락 수정

### DIFF
--- a/src/main/java/dev/wetox/WetoxRESTful/user/UserController.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/user/UserController.java
@@ -4,10 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -22,6 +19,13 @@ public class UserController {
             @AuthenticationPrincipal User user
     ) {
         return ResponseEntity.ok(userService.retrieveProfile(user.getId()));
+    }
+
+    @GetMapping("/profile/{userId}")
+    public ResponseEntity<UserResponse> retrieveProfileByUserId(
+        @PathVariable Long userId
+    ) {
+        return ResponseEntity.ok(userService.retrieveProfile(userId));
     }
 
     @GetMapping("/search")

--- a/src/main/java/dev/wetox/WetoxRESTful/user/UserService.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/user/UserService.java
@@ -2,6 +2,8 @@ package dev.wetox.WetoxRESTful.user;
 
 import dev.wetox.WetoxRESTful.exception.MemberNotFoundException;
 import dev.wetox.WetoxRESTful.image.ImageService;
+import dev.wetox.WetoxRESTful.screentime.ScreenTimeResponse;
+import dev.wetox.WetoxRESTful.screentime.ScreenTimeService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -18,13 +20,16 @@ import java.util.stream.Collectors;
 public class UserService {
     private final UserRepository userRepository;
     private final ImageService imageService;
+    private final ScreenTimeService screenTimeService;
 
     public UserResponse retrieveProfile(Long userId) {
         User user = userRepository.findById(userId).orElseThrow(MemberNotFoundException::new);
+        ScreenTimeResponse screenTime = screenTimeService.retrieveScreenTime(userId);
         return UserResponse.builder()
                 .userId(user.getId())
                 .nickname(user.getNickname())
                 .profileImage(imageService.getImageUrl(user.getProfileImageUUID()))
+                .totalDuration(screenTime.getTotalDuration())
                 .build();
     }
 


### PR DESCRIPTION
## 작업 내용
resolve Issue #33 
사용자 프로필 응답 생성을 위해 모든 코드가 UserService.retriveProfile을 사용중.
해당 메소드에서 totalDuration 필드가 누락되어 문제가 발생한 것으로 파악됨.
따라서 해당 코드에서 누락된 필드를 추가함으로써 문제 해결