### PR TITLE
Issue 41 : NO_SCREEN_TIME_AT_LATE_NIGHT 검증 로직 

### DIFF
--- a/src/main/java/dev/wetox/WetoxRESTful/badge/BadgeResolvable.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/badge/BadgeResolvable.java
@@ -1,7 +1,8 @@
 package dev.wetox.WetoxRESTful.badge;
 
+import dev.wetox.WetoxRESTful.screentime.ScreenTimeRepository;
 import dev.wetox.WetoxRESTful.user.User;
 
 public interface BadgeResolvable {
-    boolean resolve(User user, BadgeRepository badgeRepository, UserBadgeRepository userBadgeRepository);
+    boolean resolve(User user, ScreenTimeRepository screenTimeRepository, BadgeRepository badgeRepository, UserBadgeRepository userBadgeRepository);
 }

--- a/src/main/java/dev/wetox/WetoxRESTful/badge/BadgeResolver.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/badge/BadgeResolver.java
@@ -1,5 +1,6 @@
 package dev.wetox.WetoxRESTful.badge;
 
+import dev.wetox.WetoxRESTful.screentime.ScreenTimeRepository;
 import dev.wetox.WetoxRESTful.user.User;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -9,19 +10,19 @@ import lombok.RequiredArgsConstructor;
 public enum BadgeResolver {
     WELCOME(new BadgeResolvable() {
         @Override
-        public boolean resolve(User user, BadgeRepository badgeRepository, UserBadgeRepository userBadgeRepository) {
+        public boolean resolve(User user, ScreenTimeRepository screenTimeRepository, BadgeRepository badgeRepository, UserBadgeRepository userBadgeRepository) {
             return true;
         }
     }),
     NO_SCREEN_TIME_ONE_DAY(new BadgeResolvable() {
         @Override
-        public boolean resolve(User user, BadgeRepository badgeRepository, UserBadgeRepository userBadgeRepository) {
+        public boolean resolve(User user, ScreenTimeRepository screenTimeRepository, BadgeRepository badgeRepository, UserBadgeRepository userBadgeRepository) {
             return false;
         }
     }),
     NO_SCREEN_TIME_ONE_WEEK(new BadgeResolvable() {
         @Override
-        public boolean resolve(User user, BadgeRepository badgeRepository, UserBadgeRepository userBadgeRepository) {
+        public boolean resolve(User user, ScreenTimeRepository screenTimeRepository, BadgeRepository badgeRepository, UserBadgeRepository userBadgeRepository) {
             return false;
         }
     }),
@@ -29,7 +30,7 @@ public enum BadgeResolver {
 
     private final BadgeResolvable badgeResolvable;
 
-    public boolean resolve(User user, BadgeRepository badgeRepository, UserBadgeRepository userBadgeRepository) {
-        return badgeResolvable.resolve(user, badgeRepository, userBadgeRepository);
+    public boolean resolve(User user, ScreenTimeRepository screenTimeRepository, BadgeRepository badgeRepository, UserBadgeRepository userBadgeRepository) {
+        return badgeResolvable.resolve(user, screenTimeRepository, badgeRepository, userBadgeRepository);
     }
 }

--- a/src/main/java/dev/wetox/WetoxRESTful/badge/BadgeResolver.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/badge/BadgeResolver.java
@@ -1,29 +1,51 @@
 package dev.wetox.WetoxRESTful.badge;
 
+import dev.wetox.WetoxRESTful.screentime.ScreenTime;
 import dev.wetox.WetoxRESTful.screentime.ScreenTimeRepository;
 import dev.wetox.WetoxRESTful.user.User;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
 @Getter
 @RequiredArgsConstructor
 public enum BadgeResolver {
-    WELCOME(new BadgeResolvable() {
+
+    NO_SCREEN_TIME_AT_LATE_NIGHT(new BadgeResolvable() {
         @Override
         public boolean resolve(User user, ScreenTimeRepository screenTimeRepository, BadgeRepository badgeRepository, UserBadgeRepository userBadgeRepository) {
-            return true;
-        }
-    }),
-    NO_SCREEN_TIME_ONE_DAY(new BadgeResolvable() {
-        @Override
-        public boolean resolve(User user, ScreenTimeRepository screenTimeRepository, BadgeRepository badgeRepository, UserBadgeRepository userBadgeRepository) {
-            return false;
-        }
-    }),
-    NO_SCREEN_TIME_ONE_WEEK(new BadgeResolvable() {
-        @Override
-        public boolean resolve(User user, ScreenTimeRepository screenTimeRepository, BadgeRepository badgeRepository, UserBadgeRepository userBadgeRepository) {
-            return false;
+            LocalTime lateNightStart = LocalTime.of(22, 0);
+            LocalTime lateNightEnd = LocalTime.of(2, 0);
+
+            LocalDate today = LocalDate.now();
+            LocalDate yesterday = today.minusDays(1);
+
+            List<ScreenTime> twoDaysNightScreenTimes = screenTimeRepository.findScreenTimeByUserId(user.getId());
+
+            //어제 기록 없을 경우 false 반환
+            boolean hasRecordsYesterday = twoDaysNightScreenTimes.stream()
+                    .anyMatch(st -> st.getUpdatedDate().toLocalDate().equals(yesterday));
+
+            if (!hasRecordsYesterday) {
+                return false;
+            }
+
+            return twoDaysNightScreenTimes.stream()
+                    .filter(st -> st.getUpdatedDate().toLocalDate().equals(today) || st.getUpdatedDate().toLocalDate().equals(yesterday))
+                    .noneMatch(st -> {
+                        LocalDateTime updatedDateTime = st.getUpdatedDate();
+                        LocalTime screenTime = updatedDateTime.toLocalTime();
+                        LocalDate screenDate = updatedDateTime.toLocalDate();
+
+                        boolean isLateNightYesterday = screenDate.equals(yesterday) && (screenTime.isAfter(lateNightStart) || screenTime.equals(lateNightStart));
+                        boolean isEarlyMorningToday = screenDate.equals(today) && screenTime.isBefore(lateNightEnd);
+
+                        return isLateNightYesterday || isEarlyMorningToday;
+                    });
         }
     }),
     ;

--- a/src/main/java/dev/wetox/WetoxRESTful/badge/BadgeService.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/badge/BadgeService.java
@@ -1,6 +1,7 @@
 package dev.wetox.WetoxRESTful.badge;
 
 import dev.wetox.WetoxRESTful.exception.UserNotFoundException;
+import dev.wetox.WetoxRESTful.screentime.ScreenTimeRepository;
 import dev.wetox.WetoxRESTful.user.User;
 import dev.wetox.WetoxRESTful.user.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +18,7 @@ public class BadgeService {
     private final UserRepository userRepository;
     private final BadgeRepository badgeRepository;
     private final UserBadgeRepository userBadgeRepository;
+    private final ScreenTimeRepository screenTimeRepository;
 
     public List<BadgeResponse> listRewardedBadge(Long userId) {
         User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
@@ -46,7 +48,7 @@ public class BadgeService {
                 .filter(badge -> !rewardedBadges.contains(badge))
                 .toList();
         for (Badge badge: notRewardedBadges) {
-            if (!badge.getBadgeResolver().resolve(user, badgeRepository, userBadgeRepository)) {
+            if (!badge.getBadgeResolver().resolve(user, screenTimeRepository, badgeRepository, userBadgeRepository)) {
                 continue;
             }
             UserBadge userBadge = UserBadge.build(user, badge);


### PR DESCRIPTION
# 테스트 결과
다음 2가지 테스트 케이스로 진행

## 1.
| 날짜 | 심야시간(22시~02시) 여부 | 반환값 | 비고 |
| ---- | ---- | ---- | ---- |
| today -2 | 심야 X ( ) | false | 첫째날 기록만 있을때 심야시간이 아니더라도 전날 기록이 없을 경우 false값 반환 확인 |
| today -1 | 심야 O ( 오전 1시, 23시 ) | false |  |
| today | 심야 X ( ) | false |  |

<img width="1425" alt="스크린샷 2024-02-18 오후 1 44 40" src="https://github.com/GDSC-Wetox/WetoxRESTful/assets/128613248/de823e6e-9d28-464c-ba0e-71c2001ff4b7">

<img width="1425" alt="스크린샷 2024-02-18 오후 1 48 36" src="https://github.com/GDSC-Wetox/WetoxRESTful/assets/128613248/722e616e-f373-4292-bf96-f21ca695e74e">

<img width="1425" alt="스크린샷 2024-02-18 오후 1 51 09" src="https://github.com/GDSC-Wetox/WetoxRESTful/assets/128613248/f29b8a11-7708-40ab-b9c1-0f0b506fd41c">


--- 
## 2.
| 날짜 | 심야시간(22시~02시) 여부 | 반환값 | 비고 |
| ---- | ---- | ---- | ---- |
| today -3 | 심야 O | false | 첫째날 기록만 있을때 전날 기록이 없을 경우 false값 반환 확인 |
| today -2 | 심야 X | false |  |
| today -1 | 심야 O (새벽 1시) | false |  |
| today | 심야 X | true | 당일 새벽 시간이 아니므로 true 반환 |

<img width="1425" alt="스크린샷 2024-02-18 오후 1 56 42" src="https://github.com/GDSC-Wetox/WetoxRESTful/assets/128613248/0a7d4103-0dfa-4bd4-b8fd-edf612aa484e">

<img width="1425" alt="스크린샷 2024-02-18 오후 1 57 51" src="https://github.com/GDSC-Wetox/WetoxRESTful/assets/128613248/33a70d6b-12c5-4da7-aef3-322a5145f892">

<img width="1425" alt="스크린샷 2024-02-18 오후 1 59 19" src="https://github.com/GDSC-Wetox/WetoxRESTful/assets/128613248/4241dcfe-a820-4b01-8300-2177242c3496">




