### PR TITLE
Feat/issue 38: 배지 검증 로직 구현

### DIFF
--- a/src/main/java/dev/wetox/WetoxRESTful/badge/BadgeResolver.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/badge/BadgeResolver.java
@@ -1,32 +1,103 @@
 package dev.wetox.WetoxRESTful.badge;
 
+import dev.wetox.WetoxRESTful.screentime.Category;
+import dev.wetox.WetoxRESTful.screentime.CategoryScreenTime;
+import dev.wetox.WetoxRESTful.screentime.ScreenTime;
 import dev.wetox.WetoxRESTful.screentime.ScreenTimeRepository;
 import dev.wetox.WetoxRESTful.user.User;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
 
 @Getter
 @RequiredArgsConstructor
 public enum BadgeResolver {
-    WELCOME(new BadgeResolvable() {
-        @Override
-        public boolean resolve(User user, ScreenTimeRepository screenTimeRepository, BadgeRepository badgeRepository, UserBadgeRepository userBadgeRepository) {
-            return true;
-        }
-    }),
+
     NO_SCREEN_TIME_ONE_DAY(new BadgeResolvable() {
         @Override
         public boolean resolve(User user, ScreenTimeRepository screenTimeRepository, BadgeRepository badgeRepository, UserBadgeRepository userBadgeRepository) {
-            return false;
+            Page<ScreenTime> screenTimePage = screenTimeRepository.findLatestByUserId(user.getId(), PageRequest.of(0, 1));
+            List<ScreenTime> latestScreenTime = screenTimePage.getContent();
+            if (latestScreenTime.isEmpty())
+                return false;
+            return latestScreenTime.get(0).getUpdatedDate().isBefore(
+                    LocalDateTime.of(LocalDateTime.now().toLocalDate(), LocalTime.MIDNIGHT)
+            );
         }
     }),
+
     NO_SCREEN_TIME_ONE_WEEK(new BadgeResolvable() {
         @Override
         public boolean resolve(User user, ScreenTimeRepository screenTimeRepository, BadgeRepository badgeRepository, UserBadgeRepository userBadgeRepository) {
-            return false;
+            Page<ScreenTime> screenTimePage = screenTimeRepository.findLatestByUserId(user.getId(), PageRequest.of(0, 1));
+            List<ScreenTime> latestScreenTime = screenTimePage.getContent();
+            if (latestScreenTime.isEmpty())
+                return false;
+            return latestScreenTime.get(0).getUpdatedDate().isBefore(
+                    LocalDateTime.of(LocalDateTime.now().minusDays(7).toLocalDate(), LocalTime.MIDNIGHT)
+            );
         }
     }),
+
+    NO_GAME_ONE_DAY(new BadgeResolvable() {
+        @Override
+        public boolean resolve(User user, ScreenTimeRepository screenTimeRepository, BadgeRepository badgeRepository, UserBadgeRepository userBadgeRepository) {
+            List<ScreenTime> screenTimes = screenTimeRepository.findByDate(
+                    user.getId(),
+                    LocalDateTime.of(LocalDateTime.now().toLocalDate(), LocalTime.MIDNIGHT)
+            );
+            Optional<ScreenTime> game = screenTimes.stream()
+                    .filter(s -> {
+                        Optional<CategoryScreenTime> gameCategoryScreenTime = s.getCategoryScreenTimes().stream()
+                                .filter(c -> c.getCategory() == Category.GAME)
+                                .findFirst();
+                        return gameCategoryScreenTime.isPresent() && gameCategoryScreenTime.get().getDuration() > 0;
+                    })
+                    .findFirst();
+            return game.map(screenTime -> screenTime.getUpdatedDate().isBefore(
+                    LocalDateTime.of(LocalDateTime.now().toLocalDate(), LocalTime.MIDNIGHT)
+            )).orElse(false);
+        }
+    }),
+
+    NO_GAME_ONE_WEEK(new BadgeResolvable() {
+        @Override
+        public boolean resolve(User user, ScreenTimeRepository screenTimeRepository, BadgeRepository badgeRepository, UserBadgeRepository userBadgeRepository) {
+            List<ScreenTime> screenTimes = screenTimeRepository.findByDate(
+                    user.getId(),
+                    LocalDateTime.of(LocalDateTime.now().toLocalDate(), LocalTime.MIDNIGHT)
+            );
+            Optional<ScreenTime> game = screenTimes.stream()
+                    .filter(s -> {
+                        Optional<CategoryScreenTime> gameCategoryScreenTime = s.getCategoryScreenTimes().stream()
+                                .filter(c -> c.getCategory() == Category.GAME)
+                                .findFirst();
+                        return gameCategoryScreenTime.isPresent() && gameCategoryScreenTime.get().getDuration() > 0;
+                    })
+                    .findFirst();
+            return game.map(screenTime -> screenTime.getUpdatedDate().isBefore(
+                    LocalDateTime.of(LocalDateTime.now().minusDays(7).toLocalDate(), LocalTime.MIDNIGHT)
+            )).orElse(false);
+        }
+    }),
+
     ;
+//    NO_SCREEN_TIME_ONE_DAY
+//    NO_SCREEN_TIME_ONE_WEEK # 스크린 타임 없는 일주일 달성
+//
+//    NO_GAME_ONE_DAY # 게임 없는 하루 달성
+//    NO_GAME_ONE_WEEK # 게임 없는 한 주 달성
+//
+//    NO_SCREEN_TIME_AT_LATE_NIGHT # 늦은 시간(22시 ~ 02시)에 스크린 타임 없음 달성
+//
+//    INFORMATION_AND_BOOK_ONE_DAY # 독서 하루 달성
+//    INFORMATION_AND_BOOK_ONE_WEEK # 독서 일주일 달성
 
     private final BadgeResolvable badgeResolvable;
 

--- a/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTimeRepository.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTimeRepository.java
@@ -18,5 +18,6 @@ public interface ScreenTimeRepository extends JpaRepository<ScreenTime, Long> {
     @Query("select s FROM ScreenTime s WHERE s.user.id = :userId and s.updatedDate <= :dateDuration ORDER BY s.updatedDate DESC")
     List<ScreenTime> findByDate(@Param("userId") Long userId, LocalDateTime dateDuration);
 
-    List<ScreenTime> findScreenTimeByUserId(Long userId);
+    @Query("SELECT s FROM ScreenTime s WHERE s.user.id = :userId and s.updatedDate BETWEEN :fromDate AND :toDate ORDER BY s.updatedDate DESC")
+    List<ScreenTime> findByDateDuration(Long userId, LocalDateTime fromDate, LocalDateTime toDate);
 }

--- a/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTimeRepository.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/screentime/ScreenTimeRepository.java
@@ -7,12 +7,16 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
 public interface ScreenTimeRepository extends JpaRepository<ScreenTime, Long> {
     @Query("SELECT s FROM ScreenTime s WHERE s.user.id = :userId ORDER BY s.updatedDate DESC")
     Page<ScreenTime> findLatestByUserId(@Param("userId") Long userId, Pageable pageable);
+
+    @Query("select s FROM ScreenTime s WHERE s.user.id = :userId and s.updatedDate <= :dateDuration ORDER BY s.updatedDate DESC")
+    List<ScreenTime> findByDate(@Param("userId") Long userId, LocalDateTime dateDuration);
 
     List<ScreenTime> findScreenTimeByUserId(Long userId);
 }


### PR DESCRIPTION
## 작업 내용
resolve issue #38 

다음의 배지 획득 여부 검증 로직을 구현하였다.
- NO_SCREEN_TIME_ONE_DAY
- NO_GAME_ONE_DAY
- NO_SCREEN_TIME_ONE_WEEK
- NO_GAME_ONE_WEEK

### NO_SCREEN_TIME_ONE_DAY
|today - 1|기대값|테스트 값|테스트 결과|
|-|-|-|-|
|```{ENT: 0, GAME: 0}```|true|true|✅|
|```{ENT: 10, GAME: 0}```|false|false|✅|
|```{ENT: 0, GAME: 0}```, ```{ENT: 10, GAME: 0}```|false|false|✅|

### NO_GAME_TIME_ONE_DAY
|today - 1|기대값|테스트 값|테스트 결과|
|-|-|-|-|
|```{ENT: 0, GAME: 0}```|true|true|✅|
|```{ENT: 0, GAME: 10}```|false|false|✅|
|```{ENT: 0, GAME: 0}```, ```{ENT: 0, GAME: 10}```|false|false|✅|

### NO_SCREEN_TIME_ONE_WEEK
|today-7|...|anyday|...|today - 1|기대값|테스트 값|테스트 결과|
|-|-|-|-|-|-|-|-|
|```{ENT: 0, GAME: 0}```||```{ENT: 0, GAME: 0}```||```{ENT: 0, GAME: 0}```|true|true|✅|
|```{ENT: 0, GAME: 0}```||```{ENT: 10, GAME: 0}```||```{ENT: 0, GAME: 0}```|false|false|✅|
|```{ENT: 0, GAME: 0}```||```{ENT: 0, GAME: 0}```, ```{ENT: 10, GAME: 0}```||```{ENT: 0, GAME: 0}```|false|false|✅|

### NO_GAME_TIME_ONE_WEEK
|today-7|...|anyday|...|today - 1|기대값|테스트 값|테스트 결과|
|-|-|-|-|-|-|-|-|
|```{ENT: 0, GAME: 0}```||```{ENT: 0, GAME: 0}```||```{ENT: 0, GAME: 0}```|true|true|✅|
|```{ENT: 0, GAME: 0}```||```{ENT: 0, GAME: 10}```||```{ENT: 0, GAME: 0}```|false|false|✅|
|```{ENT: 0, GAME: 0}```||```{ENT: 0, GAME: 0}```, ```{ENT: 0, GAME: 10}```||```{ENT: 0, GAME: 0}```|false|false|✅|
