### PR TITLE
Feat: 도서 관련 배지 검증 구현

### DIFF
--- a/src/main/java/dev/wetox/WetoxRESTful/badge/BadgeResolver.java
+++ b/src/main/java/dev/wetox/WetoxRESTful/badge/BadgeResolver.java
@@ -11,7 +11,9 @@ import lombok.RequiredArgsConstructor;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Getter
 @RequiredArgsConstructor
@@ -53,7 +55,7 @@ public enum BadgeResolver {
             return lastDate.isEqual(LocalDateTime.of(LocalDateTime.now().minusDays(7).toLocalDate(), LocalTime.MIDNIGHT));
         }
     }),
-  
+
     NO_SCREEN_TIME_AT_LATE_NIGHT(new BadgeResolvable() {
         @Override
         public boolean resolve(User user, ScreenTimeRepository screenTimeRepository, BadgeRepository badgeRepository, UserBadgeRepository userBadgeRepository) {
@@ -87,7 +89,7 @@ public enum BadgeResolver {
                     });
         }
     }),
-  
+
     NO_GAME_ONE_DAY(new BadgeResolvable() {
         @Override
         public boolean resolve(User user, ScreenTimeRepository screenTimeRepository, BadgeRepository badgeRepository, UserBadgeRepository userBadgeRepository) {
@@ -125,13 +127,105 @@ public enum BadgeResolver {
         }
     }),
 
+    INFORMATION_AND_BOOK_ONE_DAY(new BadgeResolvable() {
+        @Override
+        public boolean resolve(User user, ScreenTimeRepository screenTimeRepository, BadgeRepository badgeRepository, UserBadgeRepository userBadgeRepository) {
+            List<ScreenTime> lastDayScreenTimes = screenTimeRepository.findByDateDuration(
+                    user.getId(),
+                    LocalDateTime.of(LocalDateTime.now().minusDays(1).toLocalDate(), LocalTime.MIDNIGHT),
+                    LocalDateTime.of(LocalDateTime.now().toLocalDate(), LocalTime.MIDNIGHT)
+            );
+
+            if (lastDayScreenTimes.isEmpty())
+                return false;
+
+            for (ScreenTime screenTime : lastDayScreenTimes) {
+                if (getBookDuration(screenTime) > 0) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }),
+
+    INFORMATION_AND_BOOK_ONE_WEEK(new BadgeResolvable() {
+        @Override
+        public boolean resolve(User user, ScreenTimeRepository screenTimeRepository, BadgeRepository badgeRepository, UserBadgeRepository userBadgeRepository) {
+            List<ScreenTime> lastWeekScreenTimes = screenTimeRepository.findByDateDuration(
+                    user.getId(),
+                    LocalDateTime.of(LocalDateTime.now().minusWeeks(1).toLocalDate(), LocalTime.MIDNIGHT),
+                    LocalDateTime.of(LocalDateTime.now().toLocalDate(), LocalTime.MIDNIGHT)
+            );
+
+            if (lastWeekScreenTimes.isEmpty())
+                return false;
+
+            Map<LocalDate, Long> dailyDurations = new HashMap<>();
+
+            for (ScreenTime screenTime : lastWeekScreenTimes) {
+                LocalDate date = screenTime.getUpdatedDate().toLocalDate();
+                long duration = getBookDuration(screenTime);
+
+                dailyDurations.put(date, dailyDurations.getOrDefault(date, 0L) + duration);
+            }
+
+            LocalDate date = LocalDate.now().minusDays(7);
+
+            for (int i = 0; i < 7; i++) {
+                if (!dailyDurations.containsKey(date) || dailyDurations.get(date) == 0)
+                    return false;
+                date = date.plusDays(1);
+            }
+            return true;
+        }
+    }),
+
+    INFORMATION_AND_BOOK_ONE_MONTH(new BadgeResolvable() {
+        @Override
+        public boolean resolve(User user, ScreenTimeRepository screenTimeRepository, BadgeRepository badgeRepository, UserBadgeRepository userBadgeRepository) {
+            List<ScreenTime> lastMonthScreenTimes = screenTimeRepository.findByDateDuration(
+                    user.getId(),
+                    LocalDateTime.of(LocalDateTime.now().minusDays(30).toLocalDate(), LocalTime.MIDNIGHT),
+                    LocalDateTime.of(LocalDateTime.now().toLocalDate(), LocalTime.MIDNIGHT)
+            );
+
+            if (lastMonthScreenTimes.isEmpty())
+                return false;
+
+            Map<LocalDate, Long> dailyDurations = new HashMap<>();
+
+            for (ScreenTime screenTime : lastMonthScreenTimes) {
+                LocalDate date = screenTime.getUpdatedDate().toLocalDate();
+                long duration = getBookDuration(screenTime);
+
+                dailyDurations.put(date, dailyDurations.getOrDefault(date, 0L) + duration);
+            }
+
+            LocalDate date = LocalDate.now().minusDays(30);
+            for (int i = 0; i < 30; i++) {
+                if (!dailyDurations.containsKey(date) || dailyDurations.get(date) == 0)
+                    return false;
+                date = date.plusDays(1);
+            }
+            return true;
+        }
+    }),
     ;
+
+
 
     private final BadgeResolvable badgeResolvable;
 
     private static Long getGameDuration(ScreenTime screenTime) {
         return screenTime.getCategoryScreenTimes().stream()
                 .filter(c -> c.getCategory() == Category.GAME)
+                .map(CategoryScreenTime::getDuration)
+                .reduce(0L, Long::sum);
+    }
+
+    private static Long getBookDuration(ScreenTime screenTime) {
+        return screenTime.getCategoryScreenTimes().stream()
+                .filter(c -> c.getCategory() == Category.INFORMATION_AND_BOOK)
                 .map(CategoryScreenTime::getDuration)
                 .reduce(0L, Long::sum);
     }


### PR DESCRIPTION
# 도서 관련 배지 검증 구현

## 1. INFORMATION_AND_BOOK_ONE_DAY

today - 1 | 테스트 값 
-- | -- 
{ENT: 0, BOOK: 0} | false
{ENT: 0, BOOK: 50} | true
{ENT: 0, BOOK: 0}, {ENT: 0, BOOK: 50} | true

## 2. INFORMATION_AND_BOOK_ONE_WEEK

today - 7 ~ today -1 | 테스트 값 
-- | -- 
{ENT: 0, BOOK: 50} | true
{ENT: 0, BOOK: 0}, {ENT: 0, BOOK: 50}, .. | false



<img width="1277" alt="스크린샷 2024-02-18 오후 8 56 11" src="https://github.com/GDSC-Wetox/WetoxRESTful/assets/128613248/57149351-5ad1-4366-8097-f147ee7ac74f">


<img width="1277" alt="스크린샷 2024-02-18 오후 9 20 35" src="https://github.com/GDSC-Wetox/WetoxRESTful/assets/128613248/f16c61bb-6158-45b3-9505-f97679b0ed19">


## 3. INFORMATION_AND_BOOK_ONE_MONTH




